### PR TITLE
Make the run tables use 100% of the window width

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -127,6 +127,12 @@ div[class="tooltip-inner"] {
  margin: 10px 0 0 0;
 }
 
+#body-content {
+  width:100%;
+  padding-left:5px;
+  padding-right:5px;
+}
+
 /* backported from another version of bootstrap */
 .table > thead > tr > td.info,
 .table > tbody > tr > td.info,

--- a/pulpito/templates/layout.html
+++ b/pulpito/templates/layout.html
@@ -106,7 +106,7 @@
                 </ul>
         </div>
       </div>
-      <div class="container">
+      <div class="container" id="body-content">
         {% block body %}{% endblock %}
       </div>
       </div>


### PR DESCRIPTION
This addresses issue #10395: http://tracker.ceph.com/issues/10395

I think it looks better to have that bit of padding on the left and right, but we could kill that too if needed.