### PR TITLE
Adds a column showing how long the job was in the 'waiting' status

### DIFF
--- a/pulpito/templates/job.html
+++ b/pulpito/templates/job.html
@@ -17,6 +17,7 @@
                     <th>Updated</th>
                     <th><div class="tip" data-toggle="tooltip" title="Runtime calculated by Pulpito" data-placement="top">Runtime</div></th>
                     <th><div class="tip" data-toggle="tooltip" title="Duration reported by teuthology" data-placement="top">Duration</div></th>
+                    <th><div class="tip" data-toggle="tooltip" title="Amount of time spent in the waiting status" data-placement="top">In Waiting</div></th>
                     <th>Machine</th>
                     <th>Teuthology Branch</th>
                     <th>OS Type</th>
@@ -40,6 +41,9 @@
                         </td>
                         <td>
                             {{ job.duration }}
+                        </td>
+                        <td>
+                            {{ job.wait_time }}
                         </td>
                         <td>
                             {{ job.machine_type }}

--- a/pulpito/templates/run.html
+++ b/pulpito/templates/run.html
@@ -22,6 +22,7 @@
                                 {% include "run_table_body.html" %}
                             </tbody>
                             </table>
+                            <h2>Average wait time: {{ run.avg_wait_time }}</h2>
                         </div>
                     </div>
                 </div>
@@ -80,6 +81,7 @@
                     <th>Updated</th>
                     <th><div class="tip" data-toggle="tooltip" title="Runtime calculated by Pulpito" data-placement="left">Runtime</div></th>
                     <th><div class="tip" data-toggle="tooltip" title="Duration reported by teuthology" data-placement="left">Duration</div></th>
+                    <th><div class="tip" data-toggle="tooltip" title="Amount of time spent in the waiting status" data-placement="left">In Waiting</div></th>
                     <th>Machine</th>
                     <th>Teuthology Branch</th>
                     <th>OS Type</th>
@@ -124,6 +126,9 @@
                         </td>
                         <td>
                           {{ job['duration'] }}
+                        </td>
+                        <td>
+                          {{ job['wait_time'] }}
                         </td>
                         <td>
                           {{ job['machine_type'] }}


### PR DESCRIPTION
I thought this might be helpful.  Yesterday I wanted to get an idea of how long jobs in a run sit in the waiting status on average and I thought adding this to pulpito would be the easiest way to accomplish that.

@yuriw would something like this be helpful?

Signed-off-by: Andrew Schoen <aschoen@redhat.com>