### PR TITLE
Adds a description column to the node list page

### DIFF
--- a/pulpito/controllers/nodes.py
+++ b/pulpito/controllers/nodes.py
@@ -26,6 +26,15 @@ class NodesController(object):
         nodes = resp.json()
         for node in nodes:
             set_node_status_class(node)
+            # keep only the node name, not the fqdn
+            node['name'] = node['name'].split(".")[0]
+            desc = node['description']
+            if not desc or desc.lower() == "none":
+                node['description'] = ""
+            elif 'teuthworker' in desc:
+                # strip out the path part of the description and
+                # leave it with the run_name/job_id
+                node['description'] = "/".join(desc.split("/")[-2:])
         nodes.sort(key=lambda n: n['name'])
 
         title = "{mtype} nodes".format(

--- a/pulpito/templates/nodes.html
+++ b/pulpito/templates/nodes.html
@@ -22,6 +22,7 @@
                     <th>OS Type</th>
                     <th>OS Version</th>
                     <th>Arch</th>
+                    <th>Description</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -41,6 +42,7 @@
                       <td>{{ node.os_type|brief }}</td>
                       <td>{{ node.os_version|brief }}</td>
                       <td>{{ node.arch|brief }}</td>
+                      <td>{{ node.description }}</td>
                     </tr>
                     {% endfor %}
                   {% endif %}


### PR DESCRIPTION
This also shortens the name column to just the name of the node and
not the fqdn to allow for more room.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>