### PR TITLE
JobController: add a trailing slash to job URLs

### DIFF
--- a/pulpito/controllers/job.py
+++ b/pulpito/controllers/job.py
@@ -14,7 +14,7 @@ class JobController(object):
         self.job_id = job_id
         url = urlparse.urljoin(
             base_url,
-            "/runs/{0}/jobs/{1}".format(run_name, job_id)
+            "/runs/{0}/jobs/{1}/".format(run_name, job_id)
         )
         resp = requests.get(url)
         if resp.status_code == 400:


### PR DESCRIPTION
Signed-off-by: Zack Cerza <zack@redhat.com>