### PR TITLE
Handle edge cases with jobs missing 'started'

### DIFF
--- a/pulpito/controllers/util.py
+++ b/pulpito/controllers/util.py
@@ -101,7 +101,7 @@ def set_job_time_info(job):
         else:
             updated = datetime.strptime(job['updated'], timestamp_fmt)
             job['runtime'] = remove_delta_msecs(updated - started)
-    if job.get('duration'):
+    if job.get('duration') and job.get('runtime'):
         duration = timedelta(seconds=job['duration'])
         job['duration'] = str(duration)
         wait_time = remove_delta_msecs(job['runtime'] - duration)


### PR DESCRIPTION
If paddles is inaccessible when a job starts, it will have no 'started'
value. Don't throw an exception in those cases.

Signed-off-by: Zack Cerza <zack@redhat.com>