### PR TITLE
Use absolute links on /stats/nodes/jobs/

### DIFF
--- a/pulpito/templates/node_stats_jobs.html
+++ b/pulpito/templates/node_stats_jobs.html
@@ -33,7 +33,7 @@
                   {% set node = nodes[name] %}
                     <tr>
                       <td>
-                        <a href="../../nodes/{{ name }}">{{ name }}</a>
+                        <a href="/nodes/{{ name }}">{{ name }}</a>
                       <td>
                         {{ node.pass }}
                       </td>


### PR DESCRIPTION
Fixes a bug in https://github.com/ceph/pulpito/pull/51