### PR TITLE
Add a run detail page

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -174,6 +174,31 @@ div[class="tooltip-inner"] {
   display: inline-block !important;
 }
 
+.table {
+  display: table;
+  table-layout: auto;
+  border-bottom: 1px solid grey;
+  border-right: 1px solid grey;
+}
+
+.table .table-row {
+  display: table-row;
+  padding: 0.1em;
+  margin: 0;
+}
+
+.table .header .table-cell {
+  font-weight: bold;
+}
+
+.table .table-cell {
+  display: table-cell;
+  padding: 0.1em;
+  border-top: 1px solid #dddddd;
+  border-left: 1px solid #dddddd;
+  border-collapse: collapse;
+}
+
 
 /* Be responsive when the screen size is small */
 @media only screen and (max-width: 768px) {
@@ -197,6 +222,7 @@ div[class="tooltip-inner"] {
   }
 
   /* Force table to not be like tables anymore */
+  .table .table-cell,
   #table-flow table,
   #table-flow thead,
   #table-flow tbody,
@@ -205,7 +231,15 @@ div[class="tooltip-inner"] {
   #table-flow tr {
     display: block;
   }
+
+  .table {
+    border: none;
+    table-layout: auto;
+    display: unset;
+  }
+
 	/* Hide table headers (but not display: none;, for accessibility) */
+  .table .table-row.header,
 	#table-flow thead tr {
 		position: absolute;
 		top: -9999px;
@@ -214,23 +248,25 @@ div[class="tooltip-inner"] {
 
   #table-flow tr { border: 1px solid #ccc; }
 
+  .table .table-cell,
 	#table-flow td {
 		/* Behave  like a "row" */
 		border: none;
 		border-bottom: 1px solid #eee;
 		position: relative;
-		padding-left: 50%;
+		padding-left: 25%;
 		white-space: normal;
 		text-align:left;
 	}
 
+  .table .table-cell:before,
 	#table-flow td:before {
 		/* Now like a table header */
 		position: absolute;
 		/* Top/left values mimic padding */
 		top: 6px;
 		left: 6px;
-		width: 45%;
+		width: 25%;
 		padding-right: 10px;
 		white-space: nowrap;
 		text-align:left;
@@ -239,4 +275,54 @@ div[class="tooltip-inner"] {
 
   /* Label the data */
 	#table-flow td:before { content: attr(data-title); }
+  .table .table-cell:before { content: attr(data-title); }
+
+  .table .table-row {
+    display: block;
+    border-top: 1px solid gray;
+  }
 }
+
+/* Render a .table / .table-row / .table-cell construct as a set of cards */
+.card-stack {
+  table-display: auto;
+  display: unset;
+}
+
+.card-stack.table .table-row {
+  display: block;
+  border-top: 1px solid gray;
+}
+
+.card-stack.table .table-row.header {
+  position: absolute;
+  top: -9999px;
+  left: -9999px;
+}
+
+.card-stack.table .table-cell:before {
+  /* Now like a table header */
+  position: absolute;
+  /* Top/left values mimic padding */
+  top: 6px;
+  left: 6px;
+  width: 25%;
+  padding-right: 10px;
+  white-space: nowrap;
+  text-align:left;
+  font-weight: bold;
+  content: attr(data-title);
+}
+
+.card-stack.table .table-cell {
+  display: block;
+  border: none;
+  border-bottom: 1px solid #eee;
+  position: relative;
+  padding-left: 25%;
+  min-height: 2em;
+  white-space: normal;
+  text-align: left;
+  overflow: hidden;
+  text-overflow: ellipsis;
+ }

--- a/pulpito/controllers/root.py
+++ b/pulpito/controllers/root.py
@@ -152,6 +152,13 @@ class RunController(object):
             run=run
         )
 
+    @expose('run_detail.html')
+    def detail(self):
+        run = self.run or self.get_run()
+        return dict(
+            run=run
+        )
+
     @expose('json')
     def _lookup(self, job_id, *remainder):
         return JobController(self.name, job_id), remainder

--- a/pulpito/templates/layout.html
+++ b/pulpito/templates/layout.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
     <head>
       <title>{% block title %}{% endblock %}Pulpito :: Results Dashoard</title>

--- a/pulpito/templates/run.html
+++ b/pulpito/templates/run.html
@@ -42,6 +42,9 @@
                   </a>
                 </h2>
               {% endif %}
+              <h2>
+                <a href="/{{ run.name }}/detail"> See detail view?</a>
+              </h2>
             </div>
 
             <div class="btn-group">

--- a/pulpito/templates/run_detail.html
+++ b/pulpito/templates/run_detail.html
@@ -1,0 +1,39 @@
+{% extends "layout.html" %}
+{% block body %}
+<div class="row">
+  <div class="col-lg-12">
+    <div class="page-header">
+      <h1 class="panel-title"> {{ run.name }}</h1>
+    </div>
+    <div class="btn-group">
+      {% set results = run.results %}
+      {% if run.results.queued %}
+        <button type="button" class="btn btn-primary" id='queued-job-btn'>{{ run.results.queued }} Queued</button>
+      {% endif %}
+      {% if run.results.fail %}
+        <button type="button" class="btn btn-danger" id='fail-job-btn'>{{ run.results.fail }} Failed</button>
+      {% endif %}
+      {% if run.results.dead %}
+        <button type="button" class="btn btn-danger" id='dead-job-btn'>{{ run.results.dead }} Dead</button>
+      {% endif %}
+      {% if run.results.running %}
+        <button type="button" class="btn btn-warning" id='running-job-btn'>{{ run.results.running }} Running</button>
+      {% endif %}
+      {% if results.waiting %}
+        <button type="button" class="btn btn-info" id='waiting-job-btn'>{{ results.waiting }} Waiting</button>
+      {% endif %}
+      {% if run.results.unknown %}
+        <button type="button" class="btn btn-warning" id='unknown-job-btn'>{{ run.results.unknown }} Unknown</button>
+      {% endif %}
+      {% if run.results.pass %}
+        <button type="button" class="btn btn-success" id='pass-job-btn'>{{ run.results.pass }} Passed</button>
+      {% endif %}
+        <button type="button" class="btn btn-primary active" id='all-job-btn'>{{ run.results.total }} Total</button>
+    </div>
+    <div class="bs-example">
+      {% set jobs = run.jobs %}
+      {% include "run_jobs_detail.html" %}
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/pulpito/templates/run_jobs_detail.html
+++ b/pulpito/templates/run_jobs_detail.html
@@ -1,0 +1,44 @@
+<div class='table card-stack'>
+<div class='table-row header'>
+  <div class='table-cell'>ID</div>
+  <div class='table-cell'>Status</div>
+  <div class='table-cell'>Ceph Branch</div>
+  <div class='table-cell'>Suite Branch</div>
+  <div class='table-cell'>Teuthology Branch</div>
+  <div class='table-cell'>Machine</div>
+  <div class='table-cell'>OS</div>
+  <div class='table-cell'>Nodes</div>
+  <div class='table-cell'>Description</div>
+  <div class='table-cell'>Failure Reason</div>
+</div>
+{% for job in jobs %}
+<div id="{{ job.job_id }}" class="table-row job job_{{job.status}} alert-{{ job.status_class }}">
+    <div class='table-cell' data-title='ID:'>
+      <a href="#{{ job.job_id }}">
+        <span class="glyphicon glyphicon-link" />
+      </a>
+      <a href="/{{ job.name }}/{{ job.job_id }}">{{ job['job_id'] }}</a>
+    </div>
+    <div class='table-cell' data-title="Status:">
+      <a href="{{ job.log_href }}">{{ job.status|upper }}</a>
+    </div>
+    <div class='table-cell' data-title="Ceph Branch:">{{ job.branch }}</div>
+    <div class='table-cell' data-title="Suite Branch:">{{ job.suite_branch }}</div>
+    <div class='table-cell' data-title="Teuthology Branch:">{{ job.teuthology_branch }}</div>
+    <div class='table-cell' data-title="Machine:">{{ job.machine_type }}</div>
+    {% set os_str = '&nbsp;'.join([job.os_type|default(''), job.os_version|default('')]) %}
+    <div class='table-cell' data-title="OS:">{{ os_str }}</div>
+    <div class='table-cell' data-title="Targets:">
+    {% if job.targets %}
+    {% for node in job.targets.keys()|sort %}
+      <a href='/nodes/{{ node }}'>{{ node.split('@')[-1].split('.')[0] }}</a>
+    {% endfor %}
+    {% endif %}
+    </div>
+    <div class='table-cell' data-title="Description:">{{ job.description }}</div>
+    {% if job.failure_reason %}
+    <div class='table-cell' data-title="Failure Reason:">{{ job.failure_reason }}</div>
+    {% endif %}
+</div>
+{% endfor %}
+</div>


### PR DESCRIPTION
This is at the request of @vasukulkarni, to make it easier for testers to see more information about each job in a run. It does not replace the default view, but supplements it.