### PR TITLE
run_jobs_table: add show description button

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -122,6 +122,11 @@ $( document ).ready(function() {
         $('#expand-fail-btn').text((open_panel_count ? "Collapse" : "Expand") + " All")
     }
     update_toggle_button(); // Run once on page load to text #expand-fail-btn
+    open_desc_count = 0;
+    function update_description_button() {
+        $('#expand-desc-btn').text((open_desc_count ? "Hide" : "Show") + " Description")
+    }
+    update_description_button(); // Run once on page load to text #expand-desc-btn
 
     $('#expand-fail-btn').click(function() {
         var open_rows = $("tr.job:visible").next("tr.job_fail_extra");
@@ -130,6 +135,44 @@ $( document ).ready(function() {
         } else {
             open_rows.find('.collapse').collapse('show');
         }
+    });
+
+    function show_hide_desc() {
+        var show_columns = ["Description"];
+        var hide_columns = [
+                "Posted",
+                "Started",
+                "Updated",
+                "Runtime",
+                "In Waiting",
+                "OS Type",
+                "OS Version",
+                "Teuthology Branch",
+                "Machine",
+        ];
+        show_columns.forEach( function(item) {
+            var i = $('#run-job-table').find("th:contains('" + item + "')").index() + 1
+            if (open_desc_count) {
+                $('td:nth-child(' + i  + '),th:nth-child(' + i + ')').show();
+            } else {
+                $('td:nth-child(' + i  + '),th:nth-child(' + i + ')').hide();
+            }
+        });
+        hide_columns.forEach( function(item) {
+            var i = $('#run-job-table').find("th:contains('" + item + "')").index() + 1
+            if (!open_desc_count) {
+                $('td:nth-child(' + i  + '),th:nth-child(' + i + ')').show();
+            } else {
+                $('td:nth-child(' + i  + '),th:nth-child(' + i + ')').hide();
+            }
+        });
+        update_description_button();
+        open_desc_count = (open_desc_count + 1) % 2;
+    }
+    show_hide_desc();
+
+    $('#expand-desc-btn').click(function () {
+        show_hide_desc();
     });
 
     $('.collapse').not(".panel-collapse").on('shown.bs.collapse', function () {

--- a/pulpito/templates/job.html
+++ b/pulpito/templates/job.html
@@ -78,6 +78,12 @@
             </div>
             {% endif %}
               <p>
+                Description:
+                <tt>
+                  {{ job.description }}
+                </tt>
+              </p>
+              <p>
                 Log:
                 <a href="{{ job.log_href }}" target="_blank">
                   {{ job.log_href }}

--- a/pulpito/templates/run.html
+++ b/pulpito/templates/run.html
@@ -79,6 +79,7 @@
                 <button type="button" class="btn btn-primary active" id='all-job-btn'>{{ run.results.total }} Total</button>
             </div>
             <button type="button" class="btn btn-info {{ '' if run.results.fail or run.results.dead else 'disabled'}}" id="expand-fail-btn"></button>
+            <button type="button" class="btn btn-info" id="expand-desc-btn"></button>
             <div class="bs-example">
                 {% set jobs = run.jobs %}
                 {% include "run_jobs_table.html" %}

--- a/pulpito/templates/run_jobs_table.html
+++ b/pulpito/templates/run_jobs_table.html
@@ -1,5 +1,5 @@
 <div id='table-flow'>
-<table class="table table-condensed table-striped table-bordered table-hover" style="border-collapse:collapse;">
+<table id='run-job-table' class="table table-condensed table-striped table-bordered table-hover" style="border-collapse:collapse;">
   <thead>
     <tr>
       <th>Status</th>
@@ -15,6 +15,7 @@
       <th>Teuthology Branch</th>
       <th>OS Type</th>
       <th>OS Version</th>
+      <th>Description</th>
     </tr>
   </thead>
   <tbody>
@@ -74,10 +75,13 @@
           <td data-title="OS Version">
             {{ job['os_version'] }}
           </td>
+          <td data-title="Description">
+            {{ job['description'] }}
+          </td>
         </tr>
         {% if job.failure_reason %}
           <tr class="tablesorter-childRow job_fail_extra">
-            <td colspan="12" class="hiddenRow"><div class="collapse" id="{{ job.job_id }}">
+            <td colspan="14" class="hiddenRow"><div class="collapse" id="{{ job.job_id }}">
               Failure Reason:
               <p class="code-text">
                 {{ job.failure_reason|e }}


### PR DESCRIPTION
Add 'Show Description' button which toggles run jobs table
to show only following columns:
'Description', 'Duration', 'Links', 'Job ID', 'Status'.

This makes it easy to observe which tests are failed
and makes it possilbe to quickly copy the description.

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>