### PR TITLE
config.py.in: revert change breaking pulpito role

### DIFF
--- a/config.py.in
+++ b/config.py.in
@@ -6,6 +6,10 @@ server = {
     'host': os.environ.get('PULPITO_SERVER_HOST', '0.0.0.0')
 }
 
+# In the ceph-cm-ansible pulpito role the setup_pulpito task
+# replaces last occurance of 'paddles_address' assignment
+# using regex, that is why it should be one line expression.
+
 paddles_address = 'http://sentry.front.sepia.ceph.com:8080'
 paddles_address = os.environ.get('PULPITO_PADDLES_ADDRESS', paddles_address)
 

--- a/config.py.in
+++ b/config.py.in
@@ -6,8 +6,8 @@ server = {
     'host': os.environ.get('PULPITO_SERVER_HOST', '0.0.0.0')
 }
 
-paddles_address = os.environ.get('PULPITO_PADDLES_ADDRESS',
-                                 'http://sentry.front.sepia.ceph.com:8080')
+paddles_address = 'http://sentry.front.sepia.ceph.com:8080'
+paddles_address = os.environ.get('PULPITO_PADDLES_ADDRESS', paddles_address)
 
 # Pecan Application Configurations
 app = {


### PR DESCRIPTION
Corresponding step of pulpito role task it is fixing:
https://github.com/ceph/ceph-cm-ansible/blob/master/roles/pulpito/tasks/setup_pulpito.yml#L51-56

```
- name: Set paddles_address
  lineinfile:
    dest: "{{ pulpito_repo_path }}/prod.py"
    regexp: "^paddles_address = "
    line: "paddles_address = '{{ paddles_address|mandatory }}'"
  register: pulpito_config
```

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>