### PR TITLE
requirements: update WebOb && MarkupSafe to latest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Jinja2==2.9.5
 Mako==1.0.2
-MarkupSafe==0.18
-WebOb==1.2.3
+MarkupSafe==1.1.1
+WebOb==1.8.6
 WebTest==2.0.18
 beautifulsoup4==4.3.2
 flake8


### PR DESCRIPTION
WebOb 1.2.3 && MarkupSafe 0.18  no longer compatible
with the latest version of pecan (1.4.0). Therefore,
we need to update thme to the latest version.

Signed-off-by: Kamoltat Sirivadhna <ksirivad@redhat.com>