### PR TITLE
templates/run_table_body.html: fix home page display

### DIFF
--- a/pulpito/templates/run_table_body.html
+++ b/pulpito/templates/run_table_body.html
@@ -15,7 +15,12 @@
 		{% endif %}
     </td>
   {% endfor %}
-  <td data-title="Revision"><a href="/?sha1={{ run['sha1']}}" target="_blank" title="Show all runs for '{{ run['sha1'][0:256] }}'">{{ run['sha1'][0:7] }}</a></td>
+  <td data-title="Revision">{%
+    if run and 'sha1' in run and run['sha1']
+      %}<a href="/?sha1={{ run['sha1']}}" target="_blank" title="Show all runs for '{{ run['sha1'][0:256] }}'">{{ run['sha1'][0:7] }}</a>{%
+    else
+      %}&mdash;{%
+    endif %}</td>
   {% if results.queued|int > 0 %}<td data-title="Queued">{{ run['results']['queued'] }}</td>{% endif %}
   {% if results.pass|int > 0 %}<td data-title="Pass">{{ run['results']['pass'] }}</td>{% endif %}
   {% if results.fail|int > 0 %}<td data-title="Fail">{{ run['results']['fail'] }}</td>{% endif %}


### PR DESCRIPTION
Sometimes the sha1 can not be defined for a run
and correspondingly the template for the main page
is failed to be rendered failing with the message
'An error occurred!' and the following stack trace:

    Traceback (most recent call last):
      File "/home/pulpito/pulpito/virtualenv/lib/python2.7/site-packages/pecan/middleware/debug.py", line 78, in __call__
        return self.app(environ, start_response)
      File "/home/pulpito/pulpito/virtualenv/lib/python2.7/site-packages/pecan/middleware/recursive.py", line 56, in __call__
        return self.application(environ, start_response)
      File "/home/pulpito/pulpito/virtualenv/lib/python2.7/site-packages/pecan/middleware/errordocument.py", line 75, in __call__
        app_iter = self.app(environ, replacement_start_response)
      File "/home/pulpito/pulpito/virtualenv/lib/python2.7/site-packages/pecan/core.py", line 852, in __call__
        return super(Pecan, self).__call__(environ, start_response)
      File "/home/pulpito/pulpito/virtualenv/lib/python2.7/site-packages/pecan/core.py", line 693, in __call__
        self.invoke_controller(controller, args, kwargs, state)
      File "/home/pulpito/pulpito/virtualenv/lib/python2.7/site-packages/pecan/core.py", line 614, in invoke_controller
        result = self.render(template, result)
      File "/home/pulpito/pulpito/virtualenv/lib/python2.7/site-packages/pecan/core.py", line 425, in render
        return renderer.render(template, namespace)
      File "/home/pulpito/pulpito/virtualenv/lib/python2.7/site-packages/pecan/templating.py", line 159, in render
        return template.render(self.extra_vars.make_ns(namespace))
      File "/home/pulpito/pulpito/virtualenv/lib/python2.7/site-packages/jinja2/environment.py", line 1008, in render
        return self.environment.handle_exception(exc_info, True)
      File "/home/pulpito/pulpito/virtualenv/lib/python2.7/site-packages/jinja2/environment.py", line 780, in handle_exception
        reraise(exc_type, exc_value, tb)
      File "/home/pulpito/pulpito/pulpito/templates/index.html", line 1, in top-level template code
        {% extends "layout.html" %}
      File "/home/pulpito/pulpito/pulpito/templates/layout.html", line 116, in top-level template code
        {% block body %}{% endblock %}
      File "/home/pulpito/pulpito/pulpito/templates/index.html", line 47, in block "body"
        {% include "run_table.html" %}
      File "/home/pulpito/pulpito/pulpito/templates/run_table.html", line 6, in top-level template code
        {% include "run_table_body.html" %}
      File "/home/pulpito/pulpito/pulpito/templates/run_table_body.html", line 18, in top-level template code
        {{ run['sha1'][0:7] }}
    TypeError: 'NoneType' object has no attribute '__getitem__'

This patch fixes the error above and just draw m-dash whereever
it is not possible to determine sha1.

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>