### PR TITLE
requirements: bump ipdb to 0.13.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ WebOb==1.8.6
 WebTest==2.0.18
 beautifulsoup4==4.3.2
 flake8
-ipdb==0.8.1
+ipdb==0.13.9
 ipython
 mccabe
 pecan


### PR DESCRIPTION
trying to resolve this:

	ERROR: Could not find a version that satisfies the requirement ipdb==0.8.1 (from versions: 0.1dev-r1556, 0.1dev-r1713, 0.1dev-r1714, 0.1dev-r1716, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.6.1, 0.7, 0.7.1, 0.8, 0.8.1, 0.8.2, 0.8.3, 0.9.0, 0.9.1, 0.9.2, 0.9.3, 0.9.4, 0.10.0, 0.10.1, 0.10.2, 0.10.3, 0.11, 0.12, 0.12.1, 0.12.2, 0.12.3.dev0, 0.12.3, 0.13.0, 0.13.1, 0.13.2, 0.13.3, 0.13.4, 0.13.5, 0.13.6, 0.13.7, 0.13.8, 0.13.9)
	ERROR: No matching distribution found for ipdb==0.8.1

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>