### PR TITLE
Add GitHub Actions for CI and Docker test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: CI on python${{ matrix.python }} via ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python: [3.6, 3.9]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install tox
+        run: pip install tox
+      - name: Run flake8
+        run: tox -e flake8
+      - name: Run unit tests
+        run: tox -e py3

--- a/.github/workflows/docker_test.yml
+++ b/.github/workflows/docker_test.yml
@@ -1,0 +1,22 @@
+name: Docker Test
+
+on:
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  container_test:
+    runs-on: ubuntu-latest
+    name: Docker test
+    steps:
+      - uses: actions/checkout@v2
+      - name: Docker build
+        run: docker build . --file ./Dockerfile --tag ceph-pulpito-test
+      - name: Docker run
+        run: docker run -d -p 80:8080 ceph-pulpito-test
+      - name: Wait for docker to come up
+        run: sleep 4
+      - name: Check if docker is running
+        run: docker ps -a | grep ceph-pulpito-test

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,18 @@
+[tox]
+envlist = py3, flake8
+
+[testenv:py3]
+basepython=python3
+sitepackages=True
+whitelist_externals=
+  py.test
+deps=
+  -r{toxinidir}/requirements.txt
+
+commands=py.test -v {posargs:pulpito}
+
+[testenv:flake8]
+basepython=python3
+deps=
+  flake8
+commands=flake8 --select=F,E9 {posargs:pulpito}


### PR DESCRIPTION
GitHub Actions could be used instead of Jenkins for running flake8 tests and python unit tests.
We can also eliminate usage of TravisCI with the GitHub Action for running the Docker tests.

Signed-off-by: Aishwarya Mathuria <amathuri@redhat.com>