### PR TITLE
correct link for suite on branch

### DIFF
--- a/pulpito/templates/run.html
+++ b/pulpito/templates/run.html
@@ -30,7 +30,7 @@
 
               {% if run.branch and run.suite %}
                 <h2>
-                  <a href="/compare?branch={{ run.branch }}&suite={{ run.suite }}" target="_blank">
+                  <a href="/?branch={{ run.branch }}&suite={{ run.suite }}" target="_blank">
                       See other runs of suite '{{ run.suite }}' on branch '{{ run.branch }}'?
                   </a>
                 </h2>


### PR DESCRIPTION
"See other runs of suite" trying to use compare when it shouldn't removing compare.

Signed-off-by: Nitzan Mordechai <nmordech@redhat.com>