### PR TITLE
Add cbt performance link

### DIFF
--- a/pulpito/templates/job.html
+++ b/pulpito/templates/job.html
@@ -101,6 +101,14 @@
                     </a>
                 </p>
               {% endif %}
+              {% if job.cbt_perf_url %}
+                <p>
+                    Sentry event:
+                    <a href="{{ job.cbt_perf_url }}" target="_blank">
+                        {{ job.cbt_perf_url }}
+                    </a>
+                </p>
+              {% endif %}
               {% if job.pcp_grafana_url %}
                 <p>
                     Performance graphs:

--- a/pulpito/templates/run_jobs_table.html
+++ b/pulpito/templates/run_jobs_table.html
@@ -48,6 +48,9 @@
             {% if job.pcp_grafana_url %}
               <a href="{{ job.pcp_grafana_url }}" target="_blank"><img src="/images/pcp_graph.png" width="24px"></a>
             {% endif %}
+            {% if job.cbt_perf_url %}
+              <a href="{{ job.cbt_perf_url }}" target="_blank"><img src="/images/pcp_graph.png" width="24px"></a>
+            {% endif %}
           </td>
           <td data-title="Posted">
             {{ job.posted|localtime }}


### PR DESCRIPTION
When cbt performance job complete, we will have a link to the performance Grafana panels that will show it.
Re-using the pcp performance icon

Signed-off-by: Nitzan Mordechai <nmordech@redhat.com>