### PR TITLE
Improve rendering of multi-line job failure reasons

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -50,6 +50,7 @@ table.link-bare td a:hover {
     font-family: 'UbuntuMono';
     background-color: #eee;
     padding-left: 25px;
+    white-space: pre-line;
 }
 
 /* Progress meter */

--- a/pulpito/templates/job.html
+++ b/pulpito/templates/job.html
@@ -119,9 +119,7 @@
               {% endif %}
               {% if job.failure_reason %}
                 <h4> Failure Reason:</h4>
-                <p class="code-text">
-                    {{ job.failure_reason|e }}
-                </p>
+                <p class="code-text">{{ job.failure_reason|e }}</p>
               {% endif %}
             </div>
             <div class="panel-group" id="detail-panel">

--- a/pulpito/templates/run_jobs_table.html
+++ b/pulpito/templates/run_jobs_table.html
@@ -93,9 +93,7 @@
           <tr class="tablesorter-childRow job_fail_extra">
             <td colspan="14" class="hiddenRow"><div class="collapse" id="{{ job.job_id }}">
               Failure Reason:
-              <p class="code-text">
-                {{ job.failure_reason|e }}
-              </p>
+              <p class="code-text">{{ job.failure_reason|e }}</p>
             </div></td>
           </tr>
         {% endif %}


### PR DESCRIPTION
Modify css code-text to preserve white space so a multi-line failure reason retains its formatting and update where it is used to display the job failure reason to avoid adding whitespace

See https://github.com/ceph/ceph/pull/65067