### PR TITLE
templates/layout: show favicon again

### DIFF
--- a/pulpito/templates/layout.html
+++ b/pulpito/templates/layout.html
@@ -3,6 +3,7 @@
     <head>
       <title>{% block title %}{% endblock %}Pulpito :: Results Dashboard</title>
       <meta name="viewport" content="width=device-width, initial-scale=1">
+      <link rel="icon" type="image/png" href="/images/pulpito.png" />
       {% block css %}
       <link href="https://maxcdn.bootstrapcdn.com/bootswatch/3.3.7/spacelab/bootstrap.min.css" rel="stylesheet" integrity="sha384-L/tgI3wSsbb3f/nW9V6Yqlaw3Gj7mpE56LWrhew/c8MIhAYWZ/FNirA64AVkB5pI" crossorigin="anonymous">
       <link rel="stylesheet" type="text/css" media="screen" href="/css/datepicker.css" />


### PR DESCRIPTION
At some point the pulpito started to show cherrypy default icon, instead of its own. Add the pulpito to the layout template, so it can be shown again.