### PR TITLE
Link to pulpito-ng

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -338,3 +338,17 @@ div[class="tooltip-inner"] {
   background: transparent;
   float: right;
 }
+
+
+.navbar-header {
+  display: flex;
+  flex-direction: column;
+}
+
+#ng-link {
+  cursor: pointer;
+  font-size: 8pt;
+  color: pink;
+  vertical-align:top;
+  align-self:flex-end;
+}

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1,3 +1,8 @@
+function replace_origin() {
+    let url = new URL(window.location.href);
+    window.location.assign(url.toString().replace(url.origin, 'https://pulpito-ng.ceph.com/'));
+}
+
 function set_filters(filters) {
     window.filters = filters;
 }

--- a/pulpito/templates/layout.html
+++ b/pulpito/templates/layout.html
@@ -30,6 +30,7 @@
           <div class="container">
           <div class="navbar-header">
             <a class="navbar-brand" onclick="navigate_with_modal('/')" href="#"> <img src="/images/pulpito-white.png" width="40px">Pulpito</a>
+            <a id="ng-link" onclick="replace_origin()">(try pulpito-ng!)</a>
           </div>
           <div>
             <form class="navbar-form navbar-left" role="search">


### PR DESCRIPTION
Clicking this should take the user to the pulpito-ng version of the page they're viewing.

Not the prettiest, but open to feedback!

<img width="264" height="126" alt="Screenshot 2026-03-25 at 19 32 32" src="https://github.com/user-attachments/assets/daa16963-01e6-4284-b3f7-784fdd5aaea1" />
